### PR TITLE
Fix PermitRootLogin changes in 18.04 without breaking others

### DIFF
--- a/12.04/Dockerfile
+++ b/12.04/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/12.10/Dockerfile
+++ b/12.10/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/13.04/Dockerfile
+++ b/13.04/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/13.10/Dockerfile
+++ b/13.10/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/14.04/Dockerfile
+++ b/14.04/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 RUN apt-get clean && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@ RUN mkdir /var/run/sshd
 
 RUN echo 'root:root' |chpasswd
 
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
 EXPOSE 22


### PR DESCRIPTION
PermitRootLogin starts sometimes, but not always, with a hash-tag. This fixes this problem.